### PR TITLE
Initialize multi-module skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Kotlin
+.gradle
+build/
+*.iml
+out/
+
+# Node
+node_modules/
+dist/
+
+# Android
+android/.gradle
+android/local.properties
+android/.idea
+android/.vscode
+android/app/build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# StravaAlt
+
+This repository contains a multi-module project that aims to provide an alternative interface to Strava.
+The backend is written in Kotlin using Ktor, the frontend is a React + TypeScript app, and
+there is a placeholder for a future Android application also written in Kotlin.
+
+## Project structure
+
+- `backend` - Ktor server exposing the API and handling Strava integration.
+- `frontend` - React + TypeScript single page application.
+- `android` - Placeholder for the future Android client.
+
+## Running the backend
+
+Use Gradle to run the server:
+
+```bash
+cd backend
+./gradlew run
+```
+
+The server will start on `http://localhost:8080`.
+
+## Running the frontend
+
+Install dependencies and start the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app will be available at `http://localhost:5173` by default.
+
+## Android project
+
+The Android module can be opened with Android Studio. It currently contains
+only a minimal activity as a starting point.

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,4 @@
+# StravaAlt Android
+
+This module will contain the future Android application written in Kotlin.
+Currently it's a minimal placeholder project.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.stravaalt.app"
+    compileSdk = 33
+
+    defaultConfig {
+        applicationId = "com.stravaalt.app"
+        minSdk = 26
+        targetSdk = 33
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.10.1")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.9.0")
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest package="com.stravaalt.app" xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="StravaAlt"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/stravaalt/app/MainActivity.kt
+++ b/android/app/src/main/java/com/stravaalt/app/MainActivity.kt
@@ -1,0 +1,11 @@
+package com.stravaalt.app
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="StravaAlt Android"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.1.0" apply false
+    kotlin("android") version "1.8.0" apply false
+}

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,9 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+rootProject.name = "strava-alt-android"
+include(":app")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    kotlin("jvm") version "1.8.0"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("io.ktor:ktor-server-netty:2.3.1")
+    implementation("io.ktor:ktor-server-core:2.3.1")
+    implementation("io.ktor:ktor-server-content-negotiation:2.3.1")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.1")
+    testImplementation(kotlin("test"))
+}
+
+application {
+    mainClass.set("com.stravaalt.ApplicationKt")
+}
+
+kotlin {
+    jvmToolchain(17)
+}

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "strava-alt-backend"

--- a/backend/src/main/kotlin/com/stravaalt/Application.kt
+++ b/backend/src/main/kotlin/com/stravaalt/Application.kt
@@ -1,0 +1,24 @@
+package com.stravaalt
+
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.plugins.contentnegotiation.*
+import kotlinx.serialization.json.Json
+
+fun main() {
+    embeddedServer(Netty, port = 8080, module = Application::module).start(wait = true)
+}
+
+fun Application.module() {
+    install(ContentNegotiation) {
+        json(Json { prettyPrint = true })
+    }
+    routing {
+        get("/") {
+            call.respondText("StravaAlt backend running")
+        }
+    }
+}

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+ktor {
+    deployment {
+        port = 8080
+    }
+    application {
+        modules = [ com.stravaalt.ApplicationKt.module ]
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>StravaAlt</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "strava-alt-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.7.0",
+    "vite": "^4.4.9",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function App() {
+  return <h1>StravaAlt Frontend</h1>
+}
+
+export default App

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()]
+})


### PR DESCRIPTION
## Summary
- set up a basic Kotlin backend using Ktor
- add a React + TypeScript frontend scaffold
- prepare an Android module as a placeholder
- document project structure
- ignore build artifacts

## Testing
- `node --version`
- `gradle -v`

------
https://chatgpt.com/codex/tasks/task_e_68617a95515483299da9b9c052b73797