### PR TITLE
Fix SLF4J warning by adding logback

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
     implementation("io.ktor:ktor-client-core:2.3.1")
     implementation("io.ktor:ktor-client-cio:2.3.1")
     implementation("io.ktor:ktor-client-content-negotiation:2.3.1")
+    // SLF4J binding for logging
+    implementation("ch.qos.logback:logback-classic:1.4.14")
     testImplementation(kotlin("test"))
 }
 

--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- add logback-classic to backend for proper SLF4J logging
- provide a minimal logback.xml configuration

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6861850e083c8329a3c23e3c5c541be8