### PR TITLE
Display user avatar and logout dropdown

### DIFF
--- a/backend/src/main/kotlin/com/stravaalt/Application.kt
+++ b/backend/src/main/kotlin/com/stravaalt/Application.kt
@@ -17,6 +17,7 @@ import io.ktor.server.sessions.cookie
 import io.ktor.server.sessions.sessions
 import io.ktor.server.sessions.get
 import io.ktor.server.sessions.set
+import io.ktor.server.sessions.clear
 import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.http.HttpMethod
 import io.ktor.client.HttpClient
@@ -99,6 +100,11 @@ fun Application.module() {
             call.respondRedirect("http://localhost:5173")
         }
 
+        get("/logout") {
+            call.sessions.clear<UserSession>()
+            call.respondRedirect("http://localhost:5173")
+        }
+
         get("/api/me") {
             val session = call.sessions.get<UserSession>()
             if (session == null) {
@@ -110,7 +116,12 @@ fun Application.module() {
                 header(HttpHeaders.Authorization, "Bearer ${session.accessToken}")
             }.body()
 
-            call.respond(UserInfo("${athlete.firstname} ${athlete.lastname}"))
+            call.respond(
+                UserInfo(
+                    name = "${athlete.firstname} ${athlete.lastname}",
+                    avatar = athlete.profile
+                )
+            )
         }
     }
 }
@@ -122,7 +133,7 @@ data class UserSession(val accessToken: String)
 data class TokenResponse(val access_token: String, val athlete: Athlete)
 
 @Serializable
-data class Athlete(val firstname: String, val lastname: String)
+data class Athlete(val firstname: String, val lastname: String, val profile: String)
 
 @Serializable
-data class UserInfo(val name: String)
+data class UserInfo(val name: String, val avatar: String)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,33 @@
+.header {
+  display: flex;
+  justify-content: flex-end;
+  padding: 1rem;
+  position: relative;
+}
+
+.user-block {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+}
+
+.menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background: white;
+  border: 1px solid #ccc;
+  padding: 0.5rem 1rem;
+  display: none;
+}
+
+.user-block:hover .menu {
+  display: block;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,20 @@
 import React, { useEffect, useState } from 'react'
+import './App.css'
+
+interface UserInfo {
+  name: string
+  avatar: string
+}
 
 function App() {
-  const [name, setName] = useState<string | null>(null)
+  const [user, setUser] = useState<UserInfo | null>(null)
 
   useEffect(() => {
     fetch('http://localhost:8080/api/me', { credentials: 'include' })
       .then(res => res.ok ? res.json() : null)
       .then(data => {
         if (data && data.name) {
-          setName(data.name as string)
+          setUser({ name: data.name as string, avatar: data.avatar as string })
         }
       })
       .catch(() => {})
@@ -16,9 +22,15 @@ function App() {
 
   return (
     <>
-      <header style={{ display: 'flex', justifyContent: 'flex-end', padding: '1rem' }}>
-        {name ? (
-          <span>{name}</span>
+      <header className="header">
+        {user ? (
+          <div className="user-block">
+            <img src={user.avatar} alt="avatar" className="avatar" />
+            <span>{user.name}</span>
+            <div className="menu">
+              <a href="http://localhost:8080/logout">Logout</a>
+            </div>
+          </div>
         ) : (
           <a href="http://localhost:8080/login">Login with Strava</a>
         )}


### PR DESCRIPTION
## Summary
- return avatar URL from backend
- include logout route
- show avatar next to name on the frontend
- reveal a dropdown menu with logout on hover

## Testing
- `gradle test` *(fails: Cannot find a Java installation...)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6861950ad1848329890cad883a6a060e