### PR TITLE
Ignore package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ out/
 # Node
 node_modules/
 dist/
+package-lock.json
 
 # Android
 android/.gradle


### PR DESCRIPTION
## Summary
- ignore `package-lock.json`

## Testing
- `npm run build` in `frontend`
- `gradle build` in `backend` *(fails: no JDK 17)*

------
https://chatgpt.com/codex/tasks/task_e_6861a2e4d968832984ad2a5d6d90fe47