### PR TITLE
Enable dev mode with auto reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ STRAVA_REDIRECT_URI=http://localhost:8080/callback
 
 The server will start on `http://localhost:8080`.
 
+### Auto-reloading both projects
+
+From the repository root you can launch both the backend and frontend in watch
+mode:
+
+```bash
+npm install
+npm run dev
+```
+
+This command starts the backend with `nodemon` and the frontend with Vite. Both
+servers restart automatically whenever code changes.
+
 ## Running the frontend
 
 Install dependencies and start the development server:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "strava-alt-root",
+  "private": true,
+  "scripts": {
+    "dev": "concurrently \"npm run backend\" \"npm run frontend\"",
+    "backend": "nodemon --watch backend/src --ext kt --exec \"cd backend && gradle run\"",
+    "frontend": "npm --prefix frontend run dev"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.0",
+    "nodemon": "^3.0.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add instructions in README for running both backend and frontend in watch mode
- add a root package.json that launches nodemon for backend and Vite for frontend
- remove extraneous lockfile and gradle.properties

## Testing
- `gradle test --console=plain | tail -n 5` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68619cd345c48329a6e9cca96f008c5b