### PR TITLE
Add Render deployment config

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+build
+.gradle

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,9 @@
+FROM gradle:8-jdk17 AS build
+WORKDIR /app
+COPY . .
+RUN gradle installDist
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/build/install/strava-alt-backend/ /app/
+CMD ["./bin/strava-alt-backend"]

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,20 @@
+services:
+  - type: web
+    name: strava-alt-backend
+    env: docker
+    rootDir: backend
+    plan: free
+    autoDeploy: true
+    dockerfilePath: Dockerfile
+    envVars:
+      - key: STRAVA_CLIENT_ID
+      - key: STRAVA_CLIENT_SECRET
+      - key: STRAVA_REDIRECT_URI
+  - type: web
+    name: strava-alt-frontend
+    env: static
+    rootDir: frontend
+    buildCommand: npm install && npm run build
+    staticPublishPath: dist
+    plan: free
+    autoDeploy: true


### PR DESCRIPTION
## Summary
- add Dockerfile for backend so Render can build it
- add render.yaml to deploy backend and frontend on commit

## Testing
- `npm install`
- `npm --prefix frontend install`
- `npm --prefix frontend run build`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_686254b330608329badc8e352d79a9da