### PR TITLE
Add activity feeds to homepage

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -66,3 +66,30 @@ a:hover {
 h1 {
   color: #8a56ff;
 }
+
+.activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+}
+
+.activity-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #eee;
+}
+
+.all-button, .back-button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: #8a56ff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.all-button:hover, .back-button:hover {
+  opacity: 0.9;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,8 +6,30 @@ interface UserInfo {
   avatar: string
 }
 
+interface Activity {
+  id: number
+  name: string
+  start_date: string
+  type: string
+}
+
+const emojiMap: Record<string, string> = {
+  Run: '🏃',
+  Ride: '🚴',
+  Swim: '🏊',
+  Walk: '🚶',
+  Hike: '🥾',
+  Workout: '🏋️',
+}
+
 function App() {
   const [user, setUser] = useState<UserInfo | null>(null)
+  const [recent, setRecent] = useState<Activity[]>([])
+  const [view, setView] = useState<'home' | 'activities'>('home')
+  const [activities, setActivities] = useState<Activity[]>([])
+  const [offset, setOffset] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
+  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     fetch('http://localhost:8080/api/me', { credentials: 'include' })
@@ -19,6 +41,39 @@ function App() {
       })
       .catch(() => {})
   }, [])
+
+  useEffect(() => {
+    if (!user) return
+    fetch('http://localhost:8080/api/activities?limit=5&offset=0', { credentials: 'include' })
+      .then(res => res.ok ? res.json() : [])
+      .then(data => setRecent(data as Activity[]))
+      .catch(() => {})
+  }, [user])
+
+  useEffect(() => {
+    if (view !== 'activities' || loading || !hasMore) return
+    setLoading(true)
+    fetch(`http://localhost:8080/api/activities?limit=20&offset=${offset}`, { credentials: 'include' })
+      .then(res => res.ok ? res.json() : [])
+      .then((data: Activity[]) => {
+        setActivities(prev => [...prev, ...data])
+        if (data.length === 0) setHasMore(false)
+      })
+      .catch(() => setHasMore(false))
+      .finally(() => setLoading(false))
+  }, [offset, view])
+
+  useEffect(() => {
+    if (view !== 'activities') return
+    const onScroll = () => {
+      if (!hasMore || loading) return
+      if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 100) {
+        setOffset(o => o + 20)
+      }
+    }
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [view, hasMore, loading])
 
   return (
     <>
@@ -37,7 +92,50 @@ function App() {
         )}
       </header>
       <main className="content">
-        <h1>Welcome to StravaAlt</h1>
+        {view === 'home' && (
+          <>
+            <h1>Welcome to StravaAlt</h1>
+            {user && (
+              <>
+                <h2>Последние активности</h2>
+                <ul className="activity-list">
+                  {recent.map(a => (
+                    <li key={a.id} className="activity-item">
+                      <span>{emojiMap[a.type] || '❓'} {a.name}</span>
+                      <span>{new Date(a.start_date).toLocaleDateString()}</span>
+                    </li>
+                  ))}
+                </ul>
+                <button
+                  onClick={() => {
+                    setActivities([])
+                    setOffset(0)
+                    setHasMore(true)
+                    setView('activities')
+                  }}
+                  className="all-button"
+                >
+                  Все
+                </button>
+              </>
+            )}
+          </>
+        )}
+        {view === 'activities' && (
+          <>
+            <button onClick={() => setView('home')} className="back-button">На главную</button>
+            <ul className="activity-list">
+              {activities.map(a => (
+                <li key={a.id} className="activity-item">
+                  <span>{emojiMap[a.type] || '❓'} {a.name}</span>
+                  <span>{new Date(a.start_date).toLocaleDateString()}</span>
+                </li>
+              ))}
+            </ul>
+            {loading && <p>Загрузка...</p>}
+            {!hasMore && <p>Это все активности</p>}
+          </>
+        )}
       </main>
     </>
   )


### PR DESCRIPTION
## Summary
- backend: add `/api/activities` endpoint to fetch paginated activities from Strava
- frontend: display last 5 activities for logged-in users
- frontend: add full activities view with infinite scroll and navigation
- frontend: style new activity lists and buttons
- use `limit` and `offset` query parameters for pagination

## Testing
- `npm install` within `frontend`
- `npm run build` within `frontend`
- `npx tsc --noEmit` within `frontend`
- `gradle build` within `backend` *(fails: Java toolchain not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a5dc0a588329861bf56916cd270a