### PR TITLE
Add callback redirect logging

### DIFF
--- a/backend/src/main/kotlin/com/travalt/Application.kt
+++ b/backend/src/main/kotlin/com/travalt/Application.kt
@@ -100,6 +100,7 @@ fun Application.module() {
                 }.body()
 
                 call.sessions.set(UserSession(token.access_token))
+                call.application.environment.log.info("Redirecting authenticated user to {}", frontendUrl)
                 call.respondRedirect(frontendUrl)
             }
 


### PR DESCRIPTION
## Summary
- log the final redirect URL inside the `/callback` handler

## Testing
- `gradle build -x test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863fe3a44f48329af8109fa045d5140