### PR TITLE
Fix CORS for Authorization header

### DIFF
--- a/backend/src/main/kotlin/com/travalt/Application.kt
+++ b/backend/src/main/kotlin/com/travalt/Application.kt
@@ -60,6 +60,7 @@ fun Application.module() {
         allowMethod(HttpMethod.Get)
         allowMethod(HttpMethod.Post)
         allowHeader(HttpHeaders.ContentType)
+        allowHeader(HttpHeaders.Authorization)
         anyHost()
     }
 


### PR DESCRIPTION
## Summary
- allow `Authorization` header in CORS configuration so `/me` works cross-origin

## Testing
- `gradle test` *(fails: Cannot find a Java installation...)*

------
https://chatgpt.com/codex/tasks/task_e_686433634908832982ccfc486c7fc2f6