### PR TITLE
Add collapsible activity details

### DIFF
--- a/backend/src/main/kotlin/com/travalt/Application.kt
+++ b/backend/src/main/kotlin/com/travalt/Application.kt
@@ -228,6 +228,11 @@ data class UserInfo(val name: String, val avatar: String)
 data class ActivitySummary(
     val id: Long,
     val name: String,
-    val start_date: String,
-    val type: String
+    val startDate: String,
+    val type: String,
+    val averageHeartrate: Double? = null,
+    val averageSpeed: Double? = null,
+    val movingTime: Int? = null,
+    val distance: Double? = null,
+    val averageCadence: Double? = null
 )

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -67,13 +67,6 @@ h1 {
   color: #8a56ff;
 }
 
-.activity-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin: 1rem 0;
-}
-
 .activity-list {
   list-style: none;
   padding: 0;
@@ -82,11 +75,29 @@ h1 {
 
 .activity-item {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   padding: 0.5rem 0;
   border-bottom: 1px solid #eee;
 }
 
+
+.activity-header {
+  display: flex;
+  justify-content: space-between;
+  background: none;
+  border: none;
+  padding: 0;
+  width: 100%;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.activity-details {
+  text-align: left;
+  margin-top: 0.5rem;
+  padding-left: 1rem;
+}
 
 .all-button, .back-button {
   padding: 0.5rem 1rem;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,8 +11,13 @@ interface UserInfo {
 interface Activity {
   id: number
   name: string
-  start_date: string
+  startDate: string
   type: string
+  averageHeartrate?: number
+  averageSpeed?: number
+  movingTime?: number
+  distance?: number
+  averageCadence?: number
 }
 
 const emojiMap: Record<string, string> = {
@@ -33,6 +38,17 @@ function App() {
   const [offset, setOffset] = useState(0)
   const [hasMore, setHasMore] = useState(true)
   const [loading, setLoading] = useState(false)
+  const [expandedId, setExpandedId] = useState<number | null>(null)
+
+  const formatTime = (seconds?: number): string => {
+    if (seconds == null) return '—'
+    const h = Math.floor(seconds / 3600)
+    const m = Math.floor((seconds % 3600) / 60)
+    const s = seconds % 60
+    return [h, m, s]
+      .map(v => v.toString().padStart(2, '0'))
+      .join(':')
+  }
 
   useEffect(() => {
     const url = new URL(window.location.href)
@@ -167,7 +183,7 @@ function App() {
                   {recent.map(a => (
                     <li key={a.id} className="activity-item">
                       <span>{emojiMap[a.type] || '❓'} {a.name}</span>
-                      <span>{new Date(a.start_date).toLocaleDateString()}</span>
+                      <span>{new Date(a.start_date).toLocaleString()}</span>
                     </li>
                   ))}
                 </ul>
@@ -181,8 +197,48 @@ function App() {
             <ul className="activity-list">
               {activities.map(a => (
                 <li key={a.id} className="activity-item">
-                  <span>{emojiMap[a.type] || '❓'} {a.name}</span>
-                  <span>{new Date(a.start_date).toLocaleString()}</span>
+                  <button
+                    className="activity-header"
+                    onClick={() =>
+                      setExpandedId(expandedId === a.id ? null : a.id)
+                    }
+                  >
+                    <span>
+                      {emojiMap[a.type] || '❓'} {a.name}
+                    </span>
+                    <span>
+                      {new Date(a.startDate).toLocaleString()}
+                    </span>
+                  </button>
+                  {expandedId === a.id && (
+                    <div className="activity-details">
+                      <div>
+                        ❤️ Средний пульс:{' '}
+                        {a.averageHeartrate?.toFixed(0) || '—'}
+                      </div>
+                      <div>
+                        💨 Средняя скорость:{' '}
+                        {a.averageSpeed
+                          ? (a.averageSpeed * 3.6).toFixed(1)
+                          : '—'}{' '}
+                        км/ч
+                      </div>
+                      <div>⏱ Время: {formatTime(a.movingTime)}</div>
+                      <div>
+                        🛣 Дистанция:{' '}
+                        {a.distance
+                          ? (a.distance / 1000).toFixed(2)
+                          : '—'}{' '}
+                        км
+                      </div>
+                      {a.type === 'Ride' && (
+                        <div>
+                          🔄 Каденс:{' '}
+                          {a.averageCadence?.toFixed(0) || '—'}
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- show extended metrics for each activity from Strava backend
- implement collapsible details in the frontend with emojis
- update styles for new UI elements

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run build`
- `apt-get install -y openjdk-17-jdk`
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68643fe437f88329a2fa7121a6bb9cbc