### PR TITLE
Add activities page header and adjust back button

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -120,11 +120,20 @@ h1 {
   cursor: pointer;
 }
 
+
 .activities-header .all-button {
   position: absolute;
   right: 0;
   top: 50%;
   transform: translateY(-50%);
+}
+
+.activities-header .back-button {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-top: 0;
 }
 
 .back-button {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -233,7 +233,10 @@ function App() {
         )}
         {view === 'activities' && (
           <>
-            <button onClick={() => setView('home')} className="back-button">На главную</button>
+            <div className="activities-header">
+              <h2>Все активности</h2>
+              <button onClick={() => setView('home')} className="back-button">Назад</button>
+            </div>
             <ul className="activity-list">
               {activities.map(a => (
                 <li key={a.id} className="activity-item">


### PR DESCRIPTION
## Summary
- show header on activities page
- rename 'На главную' button to 'Назад'
- position back button like the 'Все' button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68645dc234648329baea37c9f38d27bb