### PR TITLE
Preserve current screen on refresh

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,25 @@ function App() {
   const [loading, setLoading] = useState(false)
   const [expandedId, setExpandedId] = useState<number | null>(null)
 
+  // Restore the current view from the URL hash on initial load
+  useEffect(() => {
+    const hash = window.location.hash.replace('#', '')
+    if (hash === 'activities') {
+      setView('activities')
+    } else {
+      setView('home')
+    }
+  }, [])
+
+  // Persist the view state in the URL hash so refreshes keep the same screen
+  useEffect(() => {
+    if (view === 'activities') {
+      window.location.hash = 'activities'
+    } else {
+      window.location.hash = ''
+    }
+  }, [view])
+
   const formatTime = (seconds?: number): string => {
     if (seconds == null) return '—'
     const h = Math.floor(seconds / 3600)


### PR DESCRIPTION
## Summary
- preserve `view` state via URL hash in the React frontend

## Testing
- `npm run build` (frontend)
- `gradle test` *(fails: Cannot find a Java installation for JDK 17)*

------
https://chatgpt.com/codex/tasks/task_e_68645f7a1b088329975a740f416d9568